### PR TITLE
Integrate Google fonts via next/font

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  body {
+    @apply font-sans;
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,12 @@
 // import type { Metadata } from 'next';
 
 import AppLayout from '../components/AppLayout'; // Adjust path as per your project structure
-import '../styles/globals.css'; // Your global stylesheet, including Tailwind imports
+import './globals.css';
+
+import { Inter, Montserrat } from 'next/font/google';
+
+const inter = Inter({ subsets: ['latin'], variable: '--font-inter' });
+const montserrat = Montserrat({ subsets: ['latin'], variable: '--font-montserrat' });
 
 // Metadata for the page (replaces <Head> from 'next/head' in Pages Router)
 // You can export this directly from your layout.tsx or page.tsx files.
@@ -25,13 +30,13 @@ export const metadata = {
  */
 export default function RootLayout({ children }) {
   return (
-    <html lang="en">
+    <html lang="en" className={`${inter.variable} ${montserrat.variable}`}>
       {/* The <body> tag should not be manually added here if using AppLayout to provide it,
           or ensure AppLayout doesn't also try to render a body tag.
           Typically, AppLayout would provide the header/main/footer within the body.
           Let's assume AppLayout is structured to be the content *within* the body.
       */}
-      <body>
+      <body className="font-sans">
         <AppLayout>
           {children}
         </AppLayout>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -45,8 +45,8 @@ const config: Config = {
         },
       },
       fontFamily: {
-        sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
-        heading: ['Montserrat', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        sans: ['var(--font-inter)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        heading: ['var(--font-montserrat)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
       },
       boxShadow: {
         'card': '0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06)',


### PR DESCRIPTION
## Summary
- load Inter and Montserrat fonts with `next/font`
- apply `font-sans` globally in CSS
- expose fonts through CSS variables for Tailwind

## Testing
- `pnpm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401f1d1094832c86742c407f12bbbc