### PR TITLE
Add custom button styles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,7 +5,7 @@
 @layer components {
   /* Custom button styles using the Belzig green theme */
   .custom-btn-primary {
-    @apply bg-belzig-green-500 text-belzig-white px-4 py-2 rounded-xl shadow-button font-semibold transition-colors hover:bg-belzig-green-600;
+    @apply bg-belzig-green-500 text-belzig-white px-4 py-2 rounded-xl shadow-button font-semibold transition-colors hover:bg-belzig-green-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-belzig-green-500;
   }
 
   .custom-btn-green-outline {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,3 +1,14 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+  /* Custom button styles using the Belzig green theme */
+  .custom-btn-primary {
+    @apply bg-belzig-green-500 text-belzig-white px-4 py-2 rounded-xl shadow-button font-semibold transition-colors hover:bg-belzig-green-600;
+  }
+
+  .custom-btn-green-outline {
+    @apply bg-belzig-white border border-belzig-green-500 text-belzig-green-600 px-4 py-2 rounded-xl shadow-button font-semibold transition-colors hover:bg-belzig-green-50;
+  }
+}


### PR DESCRIPTION
## Summary
- create custom button classes for green theme with hover states and shadows

## Testing
- `pnpm run build` *(fails: Build failed because of webpack errors)*

------
https://chatgpt.com/codex/tasks/task_e_68401f1ef940832ca769fb2d17dfdb3e