### PR TITLE
Add typings for core components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 .open-next/
 .DS_Store
 dist/
+tsconfig.tsbuildinfo
 *.local
 .env*
 # keep export directory for GitHub Pages

--- a/src/__tests__/QuizView.test.tsx
+++ b/src/__tests__/QuizView.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
-import QuizView from '../components/QuizView'
+import QuizView, { QuizQuestion } from '../components/QuizView'
 
-const questionSet = [
+const questionSet: QuizQuestion[] = [
   {
     id: 'q1',
     text: 'Sample question?',

--- a/src/__tests__/badgeManager.test.tsx
+++ b/src/__tests__/badgeManager.test.tsx
@@ -8,7 +8,7 @@ jest.mock('../data/badges', () => ({
   ]
 }))
 
-const TestComponent = React.forwardRef(function TestComponent(_, ref) {
+const TestComponent = React.forwardRef<ReturnType<typeof useBadgeManager>, {}>(function TestComponent(_, ref) {
   const manager = useBadgeManager()
   React.useImperativeHandle(ref, () => manager)
   return null
@@ -18,10 +18,10 @@ describe('useBadgeManager', () => {
   it('awards a badge only once', () => {
     const ref = React.createRef<ReturnType<typeof useBadgeManager>>()
     render(<TestComponent ref={ref} />)
-    act(() => { ref.current.awardBadge('p1') })
-    expect(ref.current.earnedBadges).toContain('badge1')
-    expect(ref.current.newBadge?.id).toBe('badge1')
-    act(() => { ref.current.awardBadge('p1') })
-    expect(ref.current.earnedBadges).toHaveLength(1)
+    act(() => { ref.current!.awardBadge('p1') })
+    expect(ref.current!.earnedBadges).toContain('badge1')
+    expect(ref.current!.newBadge?.id).toBe('badge1')
+    act(() => { ref.current!.awardBadge('p1') })
+    expect(ref.current!.earnedBadges).toHaveLength(1)
   })
 })

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,7 +28,7 @@ export const metadata = {
  * @param {React.ReactNode} props.children - The child components (pages or nested layouts).
  * @returns {JSX.Element} The root HTML structure wrapping the application.
  */
-export default function RootLayout({ children }) {
+export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" className={`${inter.variable} ${montserrat.variable}`}>
       {/* The <body> tag should not be manually added here if using AppLayout to provide it,

--- a/src/components/AppLayout.tsx
+++ b/src/components/AppLayout.tsx
@@ -2,9 +2,13 @@
 import React from 'react';
 import Link from 'next/link';
 
+export interface AppLayoutProps {
+    children: React.ReactNode;
+}
+
 // Props for this component:
 // - children: The content to be rendered within the main layout area.
-const AppLayout = ({ children }) => {
+const AppLayout: React.FC<AppLayoutProps> = ({ children }) => {
     return (
         <div className="min-h-screen flex flex-col font-sans bg-bg-light text-text-dark antialiased">
             {/* Header */}

--- a/src/components/QuizApp.tsx
+++ b/src/components/QuizApp.tsx
@@ -4,9 +4,32 @@ import QuizSelectionView from './QuizSelectionView';
 import QuizView from './QuizView'; // Assuming QuizView now takes a questionSet prop
 import QuizResultsView from './QuizResultsView';
 
+interface Answer {
+    id: string;
+    text: string;
+}
+
+interface Question {
+    id: string;
+    text: string;
+    answers: Answer[];
+    correctAnswerId: string;
+    points: number;
+    imageUrl?: string;
+    imageAlt?: string;
+}
+
+interface Quiz {
+    id: string;
+    title: string;
+    description: string;
+    icon: string;
+    questionSet: Question[];
+}
+
 // Mock data for available quizzes (expanded with actual question sets)
 // In a real app, this would come from an API, a database, or TypeScript files.
-const MOCK_QUIZZES_DATA = {
+const MOCK_QUIZZES_DATA: Record<string, Quiz> = {
     quiz1: {
         id: 'quiz1',
         title: 'Brandenburg Landmarks',
@@ -51,16 +74,20 @@ const MOCK_QUIZZES_DATA = {
 };
 
 
-const QuizApp = () => {
-    const [currentView, setCurrentView] = useState('selection'); // 'selection', 'quiz', 'results'
-    const [selectedQuizData, setSelectedQuizData] = useState(null);
-    const [quizResults, setQuizResults] = useState({
+const QuizApp: React.FC = () => {
+    const [currentView, setCurrentView] = useState<'selection' | 'quiz' | 'results'>('selection');
+    const [selectedQuizData, setSelectedQuizData] = useState<Quiz | null>(null);
+    const [quizResults, setQuizResults] = useState<{
+        finalScore: number;
+        totalQuestions: number;
+        correctAnswersCount: number;
+    }>({
         finalScore: 0,
         totalQuestions: 0,
         correctAnswersCount: 0
     });
 
-    const handleSelectQuiz = (quizId) => {
+    const handleSelectQuiz = (quizId: string) => {
         const quiz = MOCK_QUIZZES_DATA[quizId];
         if (quiz) {
             setSelectedQuizData(quiz);
@@ -71,7 +98,7 @@ const QuizApp = () => {
         }
     };
 
-    const handleQuizComplete = (finalScore, totalQuestions, correctAnswersCount) => {
+    const handleQuizComplete = (finalScore: number, totalQuestions: number, correctAnswersCount: number) => {
         setQuizResults({ finalScore, totalQuestions, correctAnswersCount });
         setCurrentView('results');
     };
@@ -92,7 +119,7 @@ const QuizApp = () => {
     // Render logic based on currentView
     if (currentView === 'selection') {
         // Pass only the necessary info for selection (titles, descriptions, icons)
-        const quizzesForSelection = Object.values(MOCK_QUIZZES_DATA).map(q => ({
+        const quizzesForSelection: Array<Pick<Quiz, 'id' | 'title' | 'description' | 'icon'>> = Object.values(MOCK_QUIZZES_DATA).map(q => ({
             id: q.id,
             title: q.title,
             description: q.description,

--- a/src/components/QuizModal.tsx
+++ b/src/components/QuizModal.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import React from 'react';
-import { Quiz } from '../types'; // Assuming Quiz type is defined
 import { Language } from '../types';
 
 interface QuizModalProps {
-  quiz: Quiz | null;
+  // Using any here since Quiz type from '../types' does not include title/text fields
+  quiz: any | null;
   language: Language;
   isOpen: boolean;
   onClose: () => void;
@@ -68,7 +68,7 @@ const QuizModal: React.FC<QuizModalProps> = ({
           </p>
           {/* Example Answer Buttons */}
           <div className="space-y-3">
-             {quiz.questions[0].options[language].map((option, index) => (
+             {quiz.questions[0].options[language].map((option: string, index: number) => (
                 <button key={index} className="block w-full text-left p-3 bg-belzig-gray-50 hover:bg-belzig-gray-100 rounded-lg border border-belzig-gray-200 transition-colors">
                    {option}
                 </button>

--- a/src/components/QuizResultsView.tsx
+++ b/src/components/QuizResultsView.tsx
@@ -1,6 +1,14 @@
 // components/QuizResultsView.js (or a similar path)
 import React from 'react';
 
+export interface QuizResultsViewProps {
+    finalScore?: number;
+    totalQuestions?: number;
+    correctAnswersCount?: number;
+    onPlayAgain?: () => void;
+    onGoHome?: () => void;
+}
+
 // Props for this component:
 // - finalScore: The total score achieved by the user.
 // - totalQuestions: The total number of questions in the quiz.
@@ -8,7 +16,7 @@ import React from 'react';
 // - onPlayAgain: A function to call when the "Play Again" button is clicked.
 // - onGoHome: A function to call when the "Return to Home" button is clicked (optional).
 
-const QuizResultsView = ({
+const QuizResultsView: React.FC<QuizResultsViewProps> = ({
     finalScore = 0,
     totalQuestions = 0,
     correctAnswersCount = 0,

--- a/src/components/QuizSelectionView.tsx
+++ b/src/components/QuizSelectionView.tsx
@@ -1,11 +1,23 @@
 // components/QuizSelectionView.js (or a similar path)
 import React from 'react';
 
+export interface QuizInfo {
+    id: string;
+    title: string;
+    description: string;
+    icon: string;
+}
+
+export interface QuizSelectionViewProps {
+    quizzes?: QuizInfo[];
+    onSelectQuiz: (quizId: string) => void;
+}
+
 // Props for this component:
 // - quizzes: An array of quiz objects, each with id, title, description, icon.
 // - onSelectQuiz: A function that takes the quizId and initiates the selected quiz.
 
-const QuizSelectionView = ({ quizzes = [], onSelectQuiz }) => { // Default quizzes to empty array
+const QuizSelectionView: React.FC<QuizSelectionViewProps> = ({ quizzes = [], onSelectQuiz }) => {
     if (!quizzes || quizzes.length === 0) {
         return (
             <div className="w-full max-w-3xl mx-auto p-6 sm:p-10 text-center">

--- a/src/components/QuizView.tsx
+++ b/src/components/QuizView.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import AnswerOption from './AnswerOption'; // Assuming AnswerOption.js is in the same folder or correct path
 
 // Helper function to shuffle answers (optional, but good for quizzes)
-const shuffleArray = (array) => {
+const shuffleArray = <T,>(array: T[]): T[] => {
     if (!array) return [];
     let currentIndex = array.length, randomIndex;
     while (currentIndex !== 0) {
@@ -15,22 +15,43 @@ const shuffleArray = (array) => {
     return array;
 };
 
-const QuizView = ({
-    questionSet = [], // Expect an array of question objects
-    quizTitle = "Quiz",  // Optional title for the quiz
-    onQuizComplete      // Callback: (finalScore, totalQuestions, correctAnswersCount) => void
+interface Answer {
+    id: string;
+    text: string;
+}
+
+export interface QuizQuestion {
+    id: string;
+    text: string;
+    answers: Answer[];
+    correctAnswerId: string;
+    points: number;
+    imageUrl?: string;
+    imageAlt?: string;
+}
+
+export interface QuizViewProps {
+    questionSet?: QuizQuestion[];
+    quizTitle?: string;
+    onQuizComplete?: (score: number, total: number, correct: number) => void;
+}
+
+const QuizView: React.FC<QuizViewProps> = ({
+    questionSet = [],
+    quizTitle = "Quiz",
+    onQuizComplete
 }) => {
-    const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
-    const [currentScore, setCurrentScore] = useState(0);
-    const [correctAnswersThisQuiz, setCorrectAnswersThisQuiz] = useState(0);
+    const [currentQuestionIndex, setCurrentQuestionIndex] = useState<number>(0);
+    const [currentScore, setCurrentScore] = useState<number>(0);
+    const [correctAnswersThisQuiz, setCorrectAnswersThisQuiz] = useState<number>(0);
 
-    const questionData = questionSet[currentQuestionIndex];
+    const questionData: QuizQuestion | undefined = questionSet[currentQuestionIndex];
 
-    const [selectedAnswerId, setSelectedAnswerId] = useState(null);
-    const [answersChecked, setAnswersChecked] = useState(false);
-    const [shuffledAnswers, setShuffledAnswers] = useState([]);
-    const [feedbackMessage, setFeedbackMessage] = useState('');
-    const [isCorrect, setIsCorrect] = useState(null);
+    const [selectedAnswerId, setSelectedAnswerId] = useState<string | null>(null);
+    const [answersChecked, setAnswersChecked] = useState<boolean>(false);
+    const [shuffledAnswers, setShuffledAnswers] = useState<Answer[]>([]);
+    const [feedbackMessage, setFeedbackMessage] = useState<string>('');
+    const [isCorrect, setIsCorrect] = useState<boolean | null>(null);
 
     useEffect(() => {
         // Reset state when questionSet changes (i.e., new quiz starts)
@@ -55,7 +76,7 @@ const QuizView = ({
         setIsCorrect(null);
     }, [questionData]); // Dependency on the current question's data
 
-    const handleSelectAnswer = (answerId) => {
+    const handleSelectAnswer = (answerId: string) => {
         if (!answersChecked) {
             setSelectedAnswerId(answerId);
             setFeedbackMessage('');


### PR DESCRIPTION
## Summary
- add explicit prop interfaces for `AppLayout`, `QuizApp`, `QuizSelectionView`, and `QuizView`
- type props for `QuizResultsView` and relax typing in `QuizModal`
- update tests to use defined types and non-null assertions
- ignore `tsconfig.tsbuildinfo`

## Testing
- `pnpm exec tsc --noEmit`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684053c00154832c80a7391dd11b08aa