### PR TITLE
Fix start script fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "sh -c 'if [ -d .next ]; then next start; else next dev; fi'",
     "lint": "next lint",
     "build:worker": "opennextjs-cloudflare",
     "preview": "opennextjs-cloudflare && wrangler dev",

--- a/src/__tests__/badgeManager.test.tsx
+++ b/src/__tests__/badgeManager.test.tsx
@@ -8,7 +8,10 @@ jest.mock('../data/badges', () => ({
   ]
 }))
 
-const TestComponent = React.forwardRef<ReturnType<typeof useBadgeManager>, {}>(function TestComponent(_, ref) {
+const TestComponent = React.forwardRef<
+  ReturnType<typeof useBadgeManager>,
+  Record<string, never>
+>(function TestComponent(_, ref) {
   const manager = useBadgeManager()
   React.useImperativeHandle(ref, () => manager)
   return null

--- a/src/components/QuizModal.tsx
+++ b/src/components/QuizModal.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import React from 'react';
-import { Language } from '../types';
+import { Language, Quiz } from '../types';
 
 interface QuizModalProps {
-  // Using any here since Quiz type from '../types' does not include title/text fields
-  quiz: any | null;
+  quiz: Quiz | null;
   language: Language;
   isOpen: boolean;
   onClose: () => void;


### PR DESCRIPTION
## Summary
- start dev server when production build is missing
- tidy badge manager test typing
- type `quiz` prop in `QuizModal`

## Testing
- `pnpm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68409de7ee24832c9b4137f92d1bc56a