### PR TITLE
Add dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A fun and interactive quiz game to test your geographical knowledge, themed arou
 * Multiple quiz categories related to Points of Interest (POIs) in Bad Belzig.
 * Earn badges for completing quizzes.
 * Engaging UI with a local theme.
+* Light and dark theme toggle.
 * Built with modern web technologies.
 
 ## 🛠️ Tech Stack

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@
 
 import AppLayout from '../components/AppLayout'; // Adjust path as per your project structure
 import './globals.css';
+import { ThemeProvider } from 'next-themes';
 
 import { Inter, Montserrat } from 'next/font/google';
 
@@ -37,9 +38,11 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           Let's assume AppLayout is structured to be the content *within* the body.
       */}
       <body className="font-sans">
-        <AppLayout>
-          {children}
-        </AppLayout>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+          <AppLayout>
+            {children}
+          </AppLayout>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import ThemeToggle from './ThemeToggle';
 
 interface HeaderProps {
   onOpenBadges: () => void;
@@ -12,19 +13,22 @@ const Header: React.FC<HeaderProps> = ({ onOpenBadges, badgeCount }) => {
   const { t } = useTranslation();
   
   return (
-    <header className="bg-belzig-green-500 text-white shadow-md">
+    <header className="bg-belzig-green-500 text-white shadow-md dark:bg-belzig-green-700">
       <div className="container mx-auto px-4 py-3 flex justify-between items-center">
         <h1 className="text-xl font-heading font-bold">{t('appName')}</h1>
-        
-        <button 
-          className="flex items-center space-x-2 bg-belzig-green-600 hover:bg-belzig-green-700 px-3 py-1.5 rounded-full transition-colors"
-          onClick={onOpenBadges}
-        >
-          <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
-            <path fillRule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
-          </svg>
-          <span>{badgeCount}</span>
-        </button>
+
+        <div className="flex items-center space-x-3">
+          <ThemeToggle />
+          <button
+            className="flex items-center space-x-2 bg-belzig-green-600 hover:bg-belzig-green-700 px-3 py-1.5 rounded-full transition-colors"
+            onClick={onOpenBadges}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
+              <path fillRule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
+            </svg>
+            <span>{badgeCount}</span>
+          </button>
+        </div>
       </div>
     </header>
   );

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,44 @@
+'use client'
+
+import { useTheme } from 'next-themes'
+import { useEffect, useState } from 'react'
+import { Sun, Moon, Laptop } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => setMounted(true), [])
+
+  if (!mounted) return null
+
+  return (
+    <div className="flex items-center space-x-1">
+      <Button
+        variant={theme === 'light' ? 'secondary' : 'ghost'}
+        size="icon"
+        onClick={() => setTheme('light')}
+      >
+        <Sun className="h-4 w-4" />
+        <span className="sr-only">Light mode</span>
+      </Button>
+      <Button
+        variant={theme === 'dark' ? 'secondary' : 'ghost'}
+        size="icon"
+        onClick={() => setTheme('dark')}
+      >
+        <Moon className="h-4 w-4" />
+        <span className="sr-only">Dark mode</span>
+      </Button>
+      <Button
+        variant={theme === 'system' ? 'secondary' : 'ghost'}
+        size="icon"
+        onClick={() => setTheme('system')}
+      >
+        <Laptop className="h-4 w-4" />
+        <span className="sr-only">System</span>
+      </Button>
+    </div>
+  )
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -6,6 +6,7 @@
 import type { Config } from "tailwindcss";
 
 const config: Config = {
+  darkMode: 'class',
   content: [
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",


### PR DESCRIPTION
## Summary
- support dark mode via ThemeProvider and ThemeToggle
- add a theme toggle control in the header
- enable `darkMode` in Tailwind
- mention theme toggle in README

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6840a86783d4832caa96be7c9d60e393