### PR TITLE
Fix build error by marking quiz components as client

### DIFF
--- a/src/components/QuizApp.tsx
+++ b/src/components/QuizApp.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // components/QuizApp.js (or a similar path)
 import React, { useState } from 'react';
 import QuizSelectionView from './QuizSelectionView';

--- a/src/components/QuizView.tsx
+++ b/src/components/QuizView.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 // components/QuizView.js (or a similar path)
 import React, { useState, useEffect } from 'react';
 import Image from 'next/image';


### PR DESCRIPTION
## Summary
- add `"use client"` directive to `QuizApp` and `QuizView`

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6840ab6bf2e4832c924afcbd16e9f3e5