### PR TITLE
Fix leftover test comment in POIs data

### DIFF
--- a/src/data/pois.ts
+++ b/src/data/pois.ts
@@ -3,7 +3,6 @@ import { POI } from '../types';
 /**
  * Points of Interest (POIs) for Bad Belzig
  * Coordinates based on user-provided DMS, converted to Decimal Degrees.
- * Includes "TEST NAME" modification for deployment verification.
  */
 
 export const pois: POI[] = [
@@ -15,7 +14,7 @@ export const pois: POI[] = [
     },
     geofenceRadius: 50, // in meters
     names: {
-      en: 'Burg Eisenhardt', // <<< Includes TEST NAME
+      en: 'Burg Eisenhardt',
       de: 'Burg Eisenhardt'
     },
     descriptions: {


### PR DESCRIPTION
## Summary
- remove leftover `TEST NAME` comments from `src/data/pois.ts`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6840b23c4984832c99a14778f1a47a3d