### PR TITLE
Fix Netlify static export config

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,18 @@ GeoQuiz can be published as a static site using GitHub Pages:
 3. In your repository settings, enable **GitHub Pages** and choose the
    appropriate source (the `docs/` folder or the `gh-pages` branch).
 
+### Deployment on Netlify
+
+To deploy on Netlify with the `/GeoQuiz` base path, export the site into a
+subdirectory and set the publish directory to `out`:
+
+```bash
+pnpm run build && next export --outdir out/GeoQuiz
+```
+
+The included `netlify.toml` enables the official Netlify Next.js plugin and
+uses this configuration automatically.
+
 ## 🗺️ Project Structure
 
 * `/public`: Static assets (images, badge SVGs).

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,7 @@
- [build]
-  command = "pnpm run build"
-  publish = ".next"
+
+[build]
+  command = "pnpm run build && next export --outdir out/GeoQuiz"
+  publish = "out"
 
 # Ensure the official Netlify plugin for Next.js is used
 [[plugins]]


### PR DESCRIPTION
## Summary
- export Netlify site to `out/GeoQuiz`
- document Netlify deploy step in README

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6840b3e373ac832cad6faa747ac68392