### PR TITLE
Fix Netlify build output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,11 @@ GeoQuiz can be published as a static site using GitHub Pages:
 
 ### Deployment on Netlify
 
-To deploy on Netlify with the `/GeoQuiz` base path, export the site into a
-subdirectory and set the publish directory to `out`:
+To deploy on Netlify with the `/GeoQuiz` base path, build the site and then move
+the static output into a subdirectory. Set the publish directory to `out`:
 
 ```bash
-pnpm run build && next export --outdir out/GeoQuiz
+pnpm run build && node ./scripts/move-export-to-subdir.js
 ```
 
 The included `netlify.toml` enables the official Netlify Next.js plugin and

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 
 [build]
-  command = "pnpm run build && next export --outdir out/GeoQuiz"
+  command = "pnpm run build && node ./scripts/move-export-to-subdir.js"
   publish = "out"
 
 # Ensure the official Netlify plugin for Next.js is used

--- a/scripts/move-export-to-subdir.js
+++ b/scripts/move-export-to-subdir.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+const OUT_DIR = path.join(__dirname, '..', 'out');
+const SUBDIR = path.join(OUT_DIR, 'GeoQuiz');
+
+if (!fs.existsSync(OUT_DIR)) {
+  console.error(`Export directory not found: ${OUT_DIR}`);
+  process.exit(1);
+}
+
+// Remove existing subdir if present
+if (fs.existsSync(SUBDIR)) {
+  fs.rmSync(SUBDIR, { recursive: true, force: true });
+}
+fs.mkdirSync(SUBDIR, { recursive: true });
+
+for (const entry of fs.readdirSync(OUT_DIR)) {
+  if (entry === 'GeoQuiz') continue;
+  fs.renameSync(path.join(OUT_DIR, entry), path.join(SUBDIR, entry));
+}
+


### PR DESCRIPTION
## Summary
- adjust Netlify build command for Next.js export
- document new build command for Netlify
- add helper script to move exported output to `/GeoQuiz`

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6840b8019a04832c80e6530999f8d037