### PR TITLE
Improve accessibility and toast timeout

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -20,12 +20,14 @@ const Header: React.FC<HeaderProps> = ({ onOpenBadges, badgeCount }) => {
         <div className="flex items-center space-x-3">
           <ThemeToggle />
           <button
+            aria-label={t('viewBadges')}
             className="flex items-center space-x-2 bg-belzig-green-600 hover:bg-belzig-green-700 px-3 py-1.5 rounded-full transition-colors"
             onClick={onOpenBadges}
           >
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5" viewBox="0 0 20 20" fill="currentColor">
               <path fillRule="evenodd" d="M6.267 3.455a3.066 3.066 0 001.745-.723 3.066 3.066 0 013.976 0 3.066 3.066 0 001.745.723 3.066 3.066 0 012.812 2.812c.051.643.304 1.254.723 1.745a3.066 3.066 0 010 3.976 3.066 3.066 0 00-.723 1.745 3.066 3.066 0 01-2.812 2.812 3.066 3.066 0 00-1.745.723 3.066 3.066 0 01-3.976 0 3.066 3.066 0 00-1.745-.723 3.066 3.066 0 01-2.812-2.812 3.066 3.066 0 00-.723-1.745 3.066 3.066 0 010-3.976 3.066 3.066 0 00.723-1.745 3.066 3.066 0 012.812-2.812zm7.44 5.252a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clipRule="evenodd" />
             </svg>
+            <span className="sr-only">{t('viewBadges')}</span>
             <span>{badgeCount}</span>
           </button>
         </div>

--- a/src/hooks/use-toast.ts
+++ b/src/hooks/use-toast.ts
@@ -9,7 +9,8 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+// Automatically dismiss toasts after 10 seconds
+const TOAST_REMOVE_DELAY = 10000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- add `aria-label` to the badges button for better screen reader support
- reduce toast dismissal delay to 10 seconds

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6842923806c8832c9720d3686d354cc6