### PR TITLE
Fix TypeScript errors and add confetti types

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@testing-library/react": "^16.3.0",
     "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.6.1",
+    "@types/canvas-confetti": "^1.9.0",
     "@types/jest": "^29.5.14",
     "@types/node": "^20",
     "@types/react": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,6 +198,9 @@ importers:
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.0)
+      '@types/canvas-confetti':
+        specifier: ^1.9.0
+        version: 1.9.0
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -2973,6 +2976,9 @@ packages:
 
   '@types/babel__traverse@7.20.7':
     resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
+
+  '@types/canvas-confetti@1.9.0':
+    resolution: {integrity: sha512-aBGj/dULrimR1XDZLtG9JwxX1b4HPRF6CX9Yfwh3NvstZEm1ZL7RBnel4keCPSqs1ANRu1u2Aoz9R+VmtjYuTg==}
 
   '@types/d3-array@3.2.1':
     resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
@@ -9727,6 +9733,8 @@ snapshots:
   '@types/babel__traverse@7.20.7':
     dependencies:
       '@babel/types': 7.27.3
+
+  '@types/canvas-confetti@1.9.0': {}
 
   '@types/d3-array@3.2.1': {}
 

--- a/src/__tests__/badgeManager.test.tsx
+++ b/src/__tests__/badgeManager.test.tsx
@@ -10,7 +10,7 @@ jest.mock('../data/badges', () => ({
 
 const TestComponent = React.forwardRef<
   ReturnType<typeof useBadgeManager>,
-  Record<string, never>
+  object
 >(function TestComponent(_, ref) {
   const manager = useBadgeManager()
   React.useImperativeHandle(ref, () => manager)

--- a/src/components/QuizModal.tsx
+++ b/src/components/QuizModal.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { Language, Quiz } from '../types';
+import { pois } from '../data/pois';
 import QuizComponent from './QuizComponent';
 
 interface QuizModalProps {
@@ -53,7 +54,7 @@ const QuizModal: React.FC<QuizModalProps> = ({
 
         <div className="quiz-content">
           <h3 className="font-heading text-xl md:text-2xl font-bold text-belzig-gray-900 mb-4">
-            {quiz.title[language]}
+            {pois.find(p => p.id === quiz.poiId)?.names[language] ?? ''}
           </h3>
           <QuizComponent
             quiz={quiz}


### PR DESCRIPTION
## Summary
- add `@types/canvas-confetti` dev dependency
- adjust `TestComponent` typing in `badgeManager.test.tsx`
- derive quiz title from POI data in `QuizModal`

## Testing
- `pnpm run lint`
- `pnpm run test`
- `pnpm tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6842afec8cfc832cbac109bcc3bd501f